### PR TITLE
Add multi-monitor support with auto-restart

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -33,12 +33,28 @@ function start() {
         done
     fi
 
-    cd - || true
+    cd - > /dev/null || true
+    echo "$MONITORS"
+}
+
+function monitor_changes() {
+    local last_monitors="$1"
+    while true; do
+        sleep 5
+        local current_monitors=$(xrandr --listmonitors | grep -c "^\s*[0-9]\+:")
+        if [[ "$current_monitors" -ne "$last_monitors" ]]; then
+            # We don't want to capture the echo output here, just update the value
+            start > /dev/null
+            last_monitors="$current_monitors"
+            echo "Monitor change detected. Updated to $current_monitors monitor(s)."
+        fi
+    done
 }
 
 function main() {
     checkAPIkey
-    start
+    local initial_monitors=$(start)
+    monitor_changes "$initial_monitors"
 }
 
 main

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -21,7 +21,18 @@ function start() {
 
     killall conky &> /dev/null
     cd /home/$(whoami)/.conky/Clock-With-Weather-Conky || true
-    nohup /usr/bin/conky -c app.cfg >/dev/null 2>&1 </dev/null &
+
+    # Detect monitors
+    MONITORS=$(xrandr --listmonitors | grep -c "^\s*[0-9]\+:")
+
+    if [[ "$MONITORS" -le 1 ]]; then
+        nohup /usr/bin/conky -c app.cfg >/dev/null 2>&1 </dev/null &
+    else
+        for (( i=0; i<$MONITORS; i++ )); do
+            nohup /usr/bin/conky -c app.cfg -m $i >/dev/null 2>&1 </dev/null &
+        done
+    fi
+
     cd - || true
 }
 


### PR DESCRIPTION
## Description

This PR introduces multi-monitor support for the Clock-With-Weather-Conky widget. It detects the number of connected monitors using `xrandr --listmonitors` and launches a separate Conky instance on each one with the `-m` flag when multiple displays are present. [reddit](https://www.reddit.com/r/conky/comments/pfxkn3/repeat_conky_on_two_monitors_dual_monitor_setup/)

Key changes in `scripts/start.sh`:
- **Monitor Detection**: Counts monitors and starts one Conky instance for single-monitor setups or one per monitor for multi-monitor setups (e.g., `conky -c app.cfg -m $i`).
- **Auto-Restart Loop**: A new `monitor_changes()` function polls every 5 seconds for changes in monitor count. On detection, it kills existing Conky processes and restarts them to match the new configuration. [[github](https://github.com/brndnmtthws/conky/discussions/2180)](https://github.com/brndnmtthws/conky/discussions/2180)
