### PR TITLE
Fix setup script menu integration and exit behavior

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -156,6 +156,7 @@ Terminal=false
 Name=[ Start ] Clock with Weather widget
 Exec=bash -c "REPLACE_APP_DIR/scripts/start.sh REPLACE_API_KEY"
 Type=Application
+Categories=Utility;
 GenericName[en_GB.UTF-8]=Clock with Weather Conky widget
 Icon=REPLACE_APP_DIR/images/theme/light/weather/dovora/01d.png
 '
@@ -167,6 +168,7 @@ Terminal=true
 Name=[ Setup ] Clock with Weather widget
 Exec=bash -c "REPLACE_APP_DIR/scripts/setup.sh -a REPLACE_API_KEY -c REPLACE_CITY -lc REPLACE_LANGUAGE_CODE -la REPLACE_LANG -u REPLACE_UNITS_NUMBER -t REPLACE_THEME_NUMBER -hf REPLACE_HOUR_FORMAT_12_NUMBER -wa REPLACE_CONFIG_ALIGNMENT -wx REPLACE_CONFIG_POSITION_X -wy REPLACE_CONFIG_POSITION_Y"
 Type=Application
+Categories=Settings;Utility;
 GenericName[en_GB.UTF-8]=Clock with Weather Conky widget setup
 Icon=REPLACE_APP_DIR/images/setup.png
 '
@@ -501,7 +503,7 @@ function setupWindowSettings() {
 function setupCreateStartIcons() {
     local launcherPath
     local launcher
-    local menuDir="$(xdg-user-dir)/.local/share/applications"
+    local menuDir="${HOME}/.local/share/applications"
     
     mkdir -p "${menuDir}"
 
@@ -523,7 +525,7 @@ function setupCreateStartIcons() {
 function setupCreateSetupIcons() {
     local launcherPath
     local launcher
-    local menuDir="$(xdg-user-dir)/.local/share/applications"
+    local menuDir="${HOME}/.local/share/applications"
     
     mkdir -p "${menuDir}"
 
@@ -555,7 +557,7 @@ function setupCreateSetupIcons() {
 }
 
 function setupStartApplication() {
-    setsid bash "${BASE_DIR}"/"${REPO}"/scripts/start.sh "${DEFAULT_OPENWEATHER_API_KEY}" &> /dev/null
+    setsid bash "${BASE_DIR}"/"${REPO}"/scripts/start.sh "${DEFAULT_OPENWEATHER_API_KEY}" &> /dev/null &
 
     echo
     echo "- Starting: ${C_Y}bash ${BASE_DIR}/${REPO}/scripts/start.sh ${DEFAULT_OPENWEATHER_API_KEY}${C_D}"


### PR DESCRIPTION
## Description
This PR improves the `scripts/setup.sh` script to ensure that desktop/menu shortcuts are correctly created and visible in system menus, and that the setup process can terminate cleanly after finishing.

## Changes

### 1. Corrected Application Menu Path
Fixed a bug in the `menuDir` variable where an incorrect `xdg-user-dir` call resulted in broken paths.
- **Implementation:** Changed the path to the standard `${HOME}/.local/share/applications`.

### 2. Enhanced Desktop Integration
Added the required `Categories` field to the `.desktop` file templates for both the widget starter and the setup tool.
- **Implementation:** Added `Categories=Utility;` and `Categories=Settings;Utility;`.
- **Benefit:** Without these categories, many desktop environments (GNOME, KDE, XFCE) would hide the shortcuts from the application launcher menu.

### 3. Non-blocking Application Startup
Updated the way the widget is started at the end of the setup process.
- **Implementation:** Backgrounded the `start.sh` execution in the `setupStartApplication` function.
- **Benefit:** Previously, the setup script would hang indefinitely because it was waiting for the background `start.sh` process to finish. It now displays the final "Bye!" message and exits successfully while the widget remains
running.

## Impact
- **Visibility:** The widget and its setup tool now correctly appear in the system's application menu/launcher.
- **User Experience:** The setup script no longer "gets stuck" at the end of the installation and returns the user to the prompt as expected.

## Verification Performed
- Verified that `.desktop` files are generated in `~/.local/share/applications`.
- Confirmed that the setup script exits immediately after launching the widget.
- Checked that the generated `.desktop` files contain the correct category metadata.
