### PR TITLE
Improve the installation workflow and update the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,13 @@ You can install it via the command-line with either `wget` or `curl`:
 ... via wget:
 
 ```bash
-bash -c "$(wget --no-check-certificate --no-cache --no-cookies -O- https://raw.githubusercontent.com/takattila/Clock-With-Weather-Conky/v1.0.0/scripts/install.sh)"
+bash -c "$(wget --no-check-certificate --no-cache --no-cookies -O- https://raw.githubusercontent.com/takattila/Clock-With-Weather-Conky/master/scripts/install.sh)"
 ```
 
 ... via curl:
 
 ```bash
-bash -c "$(curl -fsSLk https://raw.githubusercontent.com/takattila/Clock-With-Weather-Conky/v1.0.0/scripts/install.sh)"
+bash -c "$(curl -fsSLk https://raw.githubusercontent.com/takattila/Clock-With-Weather-Conky/master/scripts/install.sh)"
 ```
 
 [Back to top](#conky-widget-with-clock-and-current-weather-report)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -33,29 +33,20 @@ function helperGetLatestRelease() {
     sed -E 's/.*"([^"]+)".*/\1/'
 }
 
-function helperCheckout() {
-    echo
-
-    {
-        cd "${BASE_DIR}"/"${REPO}"
-        git fetch --all --tags
-        git checkout tags/"$(helperGetLatestRelease takattila/"${REPO}")"
-    } &> /dev/null
-}
-
 function helperCloneAndCheckout() {
     echo
     echo -n "- Downloading ${C_Y}${REPO}${C_D} ... "
 
+    local latestTag
+    latestTag=$(helperGetLatestRelease takattila/"${REPO}")
+
     {
-      git clone https://github.com/takattila/"${REPO}".git \
+      git clone --branch "${latestTag}" --depth 1 \
+          https://github.com/takattila/"${REPO}".git \
           "${BASE_DIR}"/"${REPO}"
     } &> /dev/null
 
     echo "done."
-
-    helperCheckout
-
     echo -e "- The ${C_Y}'${BASE_DIR}/${REPO}'${C_D} application installed."
 }
 


### PR DESCRIPTION
## **Summary**
This pull request improves the installation workflow and updates the documentation to ensure users always receive the latest stable version of the widget.

## **Changes**
### **1. Installation script improvements**
- Updated the installation logic to **clone the latest git tag directly** using  
  `git clone --branch <tag> --depth 1`  
  instead of cloning the repository HEAD and checking out the tag afterward.
- Removed the now‑unnecessary `helperCheckout()` call.
- Simplified and optimized the cloning process for faster and cleaner installs.

### **2. README updates**
- Updated the installation commands to reference the **master branch** instead of a fixed version tag (`v1.0.0`).
- Ensures users always download the most up‑to‑date installer script.

## **Why this is useful**
- Reduces installation time and network usage.
- Avoids outdated installer scripts caused by hardcoded version tags.
- Ensures the installation process always uses the latest stable release.
- Makes the project easier to maintain by removing manual version bumps in documentation.

## **Additional notes**
No functional changes to the widget itself — only installation and documentation improvements.